### PR TITLE
Csv parser hash

### DIFF
--- a/api/Pipfile
+++ b/api/Pipfile
@@ -13,6 +13,7 @@ djangorestframework-jwt = "*"
 httpie = "*"
 django-cors-headers = "*"
 djangorestframework-camel-case2 = "*"
+hashlib = "*"
 
 [dev-packages]
 coverage = "*"

--- a/api/gsn_api/gsndb/models.py
+++ b/api/gsn_api/gsndb/models.py
@@ -106,6 +106,12 @@ class School(models.Model):
     )
     notes = GenericRelation(Note)
 
+
+class FileSHA(models.Model):
+    filePath = models.CharField(max_length = 200)
+    hasher = models.TextField()
+    created = models.DateTimeField(default = timezone.now)
+
 class Program(models.Model):
     notes = GenericRelation(Note)
     name = models.CharField(max_length=50)

--- a/api/gsn_api/gsndb/templates/backend_dev_unsuccessful_hash_upload.html
+++ b/api/gsn_api/gsndb/templates/backend_dev_unsuccessful_hash_upload.html
@@ -1,0 +1,15 @@
+<html>
+  <head>
+    <title>Upload Unsuccessful</title>
+  </head>
+  <body>
+    <div>
+      <h1>Upload Unsuccessful</h1>
+      <p>This file wasn't uploaded because it has already been uploaded.</p>
+      <p>Here's what you've tried to upload:</p>
+      <p>{{file_name}}</p>
+      <p>And here's the content the file handler generated from it.</p>
+      <p>{{content}}</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Added SHA1 hash to check for duplicate csv file uploads. Appears to be working.

Only problem is I'm having some issues with migrations for some unknown reason. I had to delete the volume and rebuild. For this reason I am not pushing up my migration files.

@HTempleman and I talked about not worrying too much about maintaining the history of the migration files. In the future it will be important but for now we just need to get a product out and can ignore that. We are thinking storing historical migrations is more relevant for the deletion & changing of fields/tables, not for the original creation. Thoughts?