### PR TITLE
Fixed URL for StudentDetails page

### DIFF
--- a/frontend/src/pages/Students.js
+++ b/frontend/src/pages/Students.js
@@ -61,7 +61,7 @@ function Students(props) {
                           className={`${tRow} ${i % 2 !== 0 ? striped : ''}`}
                         >
                             <TableCell>
-                                <StyledLink component={Link} to={`/gsndb/student/${id}`}>
+                                <StyledLink component={Link} to={`/students/${id}`}>
                                     {`${firstName} ${lastName}` || ''}
                                     {/* empty string allows prop validation to work until data is loaded */}
                                 </StyledLink>


### PR DESCRIPTION
When clicking on the name of a student in Students.js, the URL for the link was not a valid page. I changed the URL to be the StudentDetails page for the student with the ID of one clicked on. This is so that the user can click on any individual student and see all of their information at once.